### PR TITLE
Add option to configure terminal window position

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ nnoremap <silent> <C-@> :ToggleTerminal<CR>
 " set your favorite shell
 let g:toggle_terminal#command = 'powershell'
 ```
+" set terminal window position
+" (see possible options at :help vertical)
+let g:toggle_terminal#position = 'topleft'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ nnoremap <silent> <C-@> :ToggleTerminal<CR>
 
 " set your favorite shell
 let g:toggle_terminal#command = 'powershell'
-```
+
 " set terminal window position
 " (see possible options at :help vertical)
 let g:toggle_terminal#position = 'topleft'
+```

--- a/autoload/toggle_terminal.vim
+++ b/autoload/toggle_terminal.vim
@@ -9,16 +9,17 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 let g:toggle_terminal#command = get(g:,'toggle_terminal#command','shell')
+let g:toggle_terminal#position = get(g:,'toggle_terminal#position','belowleft')
 
 function! toggle_terminal#ToggleTerminal()
     let bufferNum = bufnr('ToggleTerminal')
     if bufferNum == -1 || bufloaded(bufferNum) != 1
-        execute 'rightbelow term ++close ++kill=term '.g:toggle_terminal#command
+        execute g:toggle_terminal#position.' term ++close ++kill=term '.g:toggle_terminal#command
         file ToggleTerminal
     else
         let windowNum = bufwinnr(bufferNum)
         if windowNum == -1
-            execute 'rightbelow sbuffer '.bufferNum
+            execute g:toggle_terminal#position.' sbuffer '.bufferNum
         else
             execute windowNum.'wincmd w'
             hide 


### PR DESCRIPTION
Introduces g:toggle_terminal#position which may be any of the options
for splitting windows in vim, as described in :help opening-window